### PR TITLE
PHP7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 before_script:
   - composer install

--- a/src/PDODecorator.php
+++ b/src/PDODecorator.php
@@ -17,7 +17,7 @@ use PDOStatement;
 /**
  * PDO decorator, redirect calls to PDO
  */
-abstract class PDODecorator extends PDO
+abstract class PDODecorator
 {
     /**
      * Get the PDO object


### PR DESCRIPTION
[PHP Data Objects](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.pdo)
Attempting to serialize a PDO or PDOStatement instance will now generate an Exception rather than a PDOException, consistent with other internal classes which do not support serialization.